### PR TITLE
feat: update consent get methods

### DIFF
--- a/app/consent/consent.controller.ts
+++ b/app/consent/consent.controller.ts
@@ -42,6 +42,9 @@ export const controller = (prisma: PrismaClient) => {
 				where: {
 					id,
 					isDeleted: false,
+					student: {
+						isDeleted: false,
+					},
 				},
 			};
 
@@ -68,6 +71,15 @@ export const controller = (prisma: PrismaClient) => {
 				);
 
 				query.select = fieldSelections;
+			} else {
+				// Default include student with person when no specific fields are requested
+				query.include = {
+					student: {
+						include: {
+							person: true,
+						},
+					},
+				};
 			}
 
 			const consent = await prisma.consent.findFirst(query);
@@ -109,6 +121,9 @@ export const controller = (prisma: PrismaClient) => {
 				where: {
 					studentId,
 					isDeleted: false,
+					student: {
+						isDeleted: false,
+					},
 				},
 			};
 
@@ -135,6 +150,15 @@ export const controller = (prisma: PrismaClient) => {
 				);
 
 				query.select = fieldSelections;
+			} else {
+				// Default include student with person when no specific fields are requested
+				query.include = {
+					student: {
+						include: {
+							person: true,
+						},
+					},
+				};
 			}
 
 			const consent = await prisma.consent.findFirst(query);
@@ -189,6 +213,9 @@ export const controller = (prisma: PrismaClient) => {
 		try {
 			const whereClause: Prisma.ConsentWhereInput = {
 				isDeleted: false,
+				student: {
+					isDeleted: false,
+				},
 				...(query
 					? {
 							OR: [
@@ -236,6 +263,15 @@ export const controller = (prisma: PrismaClient) => {
 				);
 
 				findManyQuery.select = fieldSelections;
+			} else {
+				// Default include student with person when no specific fields are requested
+				findManyQuery.include = {
+					student: {
+						include: {
+							person: true,
+						},
+					},
+				};
 			}
 
 			const [consents, total] = await Promise.all([


### PR DESCRIPTION
This pull request improves the data integrity and default response structure for consent-related queries in the `consent.controller.ts` file. The main changes ensure that only consents for non-deleted students are returned and that, by default, student and related person data are included in responses unless specific fields are requested.

**Data integrity improvements:**

* Added a filter to all consent queries to exclude consents belonging to deleted students by adding `student: { isDeleted: false }` to the `where` clauses. [[1]](diffhunk://#diff-9245559e832a813f39461669a4f3c537b28f28b5c6918a7cd274b39a4e3b8c0eR45-R47) [[2]](diffhunk://#diff-9245559e832a813f39461669a4f3c537b28f28b5c6918a7cd274b39a4e3b8c0eR124-R126) [[3]](diffhunk://#diff-9245559e832a813f39461669a4f3c537b28f28b5c6918a7cd274b39a4e3b8c0eR216-R218)

**Default response structure enhancements:**

* Updated logic so that when no specific fields are requested, the default response now includes the related `student` and their associated `person` data using the `include` option. This applies to both single (`findFirst`) and multiple (`findMany`) consent queries. [[1]](diffhunk://#diff-9245559e832a813f39461669a4f3c537b28f28b5c6918a7cd274b39a4e3b8c0eR74-R82) [[2]](diffhunk://#diff-9245559e832a813f39461669a4f3c537b28f28b5c6918a7cd274b39a4e3b8c0eR153-R161) [[3]](diffhunk://#diff-9245559e832a813f39461669a4f3c537b28f28b5c6918a7cd274b39a4e3b8c0eR266-R274)