### PR TITLE
Refactor

### DIFF
--- a/app/metrics/metrics.controller.ts
+++ b/app/metrics/metrics.controller.ts
@@ -279,7 +279,12 @@ export const controller = (prisma: PrismaClient) => {
 		try {
 			// Get days parameter from query, default to 7 days
 			const days = parseInt(req.query.days as string) || 7;
-			metricsLogger.info(`📊 Generating chart data for frontend dashboard (${days} days)`);
+			// Get assessment type filter from query
+			const assessmentType = (req.query.assessmentType as string) || "all";
+
+			metricsLogger.info(
+				`📊 Generating chart data for frontend dashboard (${days} days, assessment: ${assessmentType})`,
+			);
 
 			// Get dashboard chart data using real metrics
 			const metrics = METRIC(prisma);
@@ -305,20 +310,17 @@ export const controller = (prisma: PrismaClient) => {
 				`📊 Trends data received: ${trendsData.length} data points for ${days} days`,
 			);
 
-			// Get program-wise breakdowns for additional insights (no date filtering)
-			const [
-				anxietyByProgram,
-				depressionByProgram,
-				stressByProgram,
-				checklistByProgram,
-				suicideByProgram,
-			] = await Promise.all([
-				metrics.Anxiety.totalAnxietyByProgram(),
-				metrics.Depression.totalDepressionByProgram(),
-				metrics.Stress.totalStressByProgram(),
-				metrics.PersonalProblemsChecklist.totalChecklistByProgram(),
-				metrics.Suicide.totalSuicideByProgram(),
-			]);
+			// Get program distribution with optional assessment type filter
+			const programDistribution =
+				await metrics.Dashboard.getProgramDistribution(assessmentType);
+
+			metricsLogger.info(
+				`📊 Program distribution received: ${programDistribution.length} programs for assessment type: ${assessmentType}`,
+			);
+
+			metricsLogger.info(
+				`📊 Program distribution received: ${programDistribution.length} programs for assessment type: ${assessmentType}`,
+			);
 
 			// Format data for charts
 			const chartData = {
@@ -410,17 +412,8 @@ export const controller = (prisma: PrismaClient) => {
 				// Monthly trends for additional line chart
 				monthlyTrends: monthlyData,
 
-				// Program distribution for insights
-				programDistribution: anxietyByProgram.map((item) => ({
-					program: item.program,
-					anxiety: item.count,
-					depression:
-						depressionByProgram.find((d) => d.program === item.program)?.count || 0,
-					stress: stressByProgram.find((s) => s.program === item.program)?.count || 0,
-					checklist:
-						checklistByProgram.find((c) => c.program === item.program)?.count || 0,
-					suicide: suicideByProgram.find((s) => s.program === item.program)?.count || 0,
-				})),
+				// Program distribution for insights (with optional assessment filter)
+				programDistribution,
 
 				// Summary stats
 				totalStats: {

--- a/app/metrics/metrics.router.ts
+++ b/app/metrics/metrics.router.ts
@@ -217,6 +217,20 @@ export const router = (route: Router, controller: IController): Router => {
 	 *   get:
 	 *     summary: Get chart-ready data for frontend visualization
 	 *     tags: [Metrics, ML Visualization]
+	 *     parameters:
+	 *       - in: query
+	 *         name: days
+	 *         schema:
+	 *           type: integer
+	 *           default: 7
+	 *         description: Number of days for trend data (7, 30, or 90)
+	 *       - in: query
+	 *         name: assessmentType
+	 *         schema:
+	 *           type: string
+	 *           enum: [all, anxiety, depression, stress, checklist, suicide]
+	 *           default: all
+	 *         description: Filter program distribution by specific assessment type
 	 *     responses:
 	 *       200:
 	 *         description: Chart data for frontend libraries
@@ -232,11 +246,17 @@ export const router = (route: Router, controller: IController): Router => {
 	 *                 data:
 	 *                   type: object
 	 *                   properties:
-	 *                     featureImportanceChart:
-	 *                       type: object
-	 *                     performanceChart:
-	 *                       type: object
-	 *                     confusionMatrixChart:
+	 *                     trendsData:
+	 *                       type: array
+	 *                     assessmentBreakdown:
+	 *                       type: array
+	 *                     severityData:
+	 *                       type: array
+	 *                     monthlyTrends:
+	 *                       type: array
+	 *                     programDistribution:
+	 *                       type: array
+	 *                     totalStats:
 	 *                       type: object
 	 *       500:
 	 *         description: Server error

--- a/app/student/student.controller.ts
+++ b/app/student/student.controller.ts
@@ -301,6 +301,21 @@ export const controller = (prisma: PrismaClient) => {
 					});
 					return;
 				}
+
+				// Validate and normalize createdAt if provided
+				if (note.createdAt !== undefined && note.createdAt !== null) {
+					// Try to parse as Date to ensure it's valid
+					const dateValue = new Date(note.createdAt);
+					if (isNaN(dateValue.getTime())) {
+						studentLogger.error(`Invalid note createdAt: ${note.createdAt}`);
+						res.status(400).json({
+							error: "Note createdAt must be a valid date",
+						});
+						return;
+					}
+					// Convert to ISO string to ensure proper format
+					note.createdAt = dateValue.toISOString();
+				}
 			}
 		}
 
@@ -517,6 +532,21 @@ export const controller = (prisma: PrismaClient) => {
 						error: "Note content must be a string",
 					});
 					return;
+				}
+
+				// Validate and normalize createdAt if provided
+				if (note.createdAt !== undefined && note.createdAt !== null) {
+					// Try to parse as Date to ensure it's valid
+					const dateValue = new Date(note.createdAt);
+					if (isNaN(dateValue.getTime())) {
+						studentLogger.error(`Invalid note createdAt: ${note.createdAt}`);
+						res.status(400).json({
+							error: "Note createdAt must be a valid date",
+						});
+						return;
+					}
+					// Convert to ISO string to ensure proper format
+					note.createdAt = dateValue.toISOString();
 				}
 			}
 		}

--- a/config/metrics.config.ts
+++ b/config/metrics.config.ts
@@ -2812,6 +2812,8 @@ export const METRIC = (prisma: PrismaClient, filter: MetricFilter = {}) => {
 		},
 		Dashboard: {
 			getRecentTrends: async (days: number = 30) => {
+				console.log(`🔍 Getting recent trends for ${days} days`);
+
 				const startDate = new Date();
 				startDate.setDate(startDate.getDate() - days);
 
@@ -3124,6 +3126,297 @@ export const METRIC = (prisma: PrismaClient, filter: MetricFilter = {}) => {
 						stress,
 					};
 				});
+			},
+
+			getProgramDistribution: async (assessmentType?: string) => {
+				console.log(`🔍 Getting program distribution, assessmentType: ${assessmentType}`);
+
+				// If specific assessment type is requested, fetch only that type
+				if (assessmentType && assessmentType !== "all") {
+					let assessments: any[] = [];
+					let countField = assessmentType.toLowerCase();
+
+					switch (assessmentType.toLowerCase()) {
+						case "anxiety":
+							assessments = await prisma.anxietyAssessment.findMany({
+								where: {
+									isDeleted: false,
+									...(filter.userFilter && { user: filter.userFilter }),
+								},
+								include: {
+									user: {
+										include: {
+											person: {
+												include: {
+													students: {
+														where: { isDeleted: false },
+													},
+												},
+											},
+										},
+									},
+								},
+							});
+							break;
+						case "depression":
+							assessments = await prisma.depressionAssessment.findMany({
+								where: {
+									isDeleted: false,
+									...(filter.userFilter && { user: filter.userFilter }),
+								},
+								include: {
+									user: {
+										include: {
+											person: {
+												include: {
+													students: {
+														where: { isDeleted: false },
+													},
+												},
+											},
+										},
+									},
+								},
+							});
+							break;
+						case "stress":
+							assessments = await prisma.stressAssessment.findMany({
+								where: {
+									isDeleted: false,
+									...(filter.userFilter && { user: filter.userFilter }),
+								},
+								include: {
+									user: {
+										include: {
+											person: {
+												include: {
+													students: {
+														where: { isDeleted: false },
+													},
+												},
+											},
+										},
+									},
+								},
+							});
+							break;
+						case "checklist":
+							assessments = await prisma.personalProblemsChecklist.findMany({
+								where: {
+									isDeleted: false,
+									...(filter.userFilter && { user: filter.userFilter }),
+								},
+								include: {
+									user: {
+										include: {
+											person: {
+												include: {
+													students: {
+														where: { isDeleted: false },
+													},
+												},
+											},
+										},
+									},
+								},
+							});
+							break;
+						case "suicide":
+							assessments = await prisma.suicideAssessment.findMany({
+								where: {
+									isDeleted: false,
+									...(filter.userFilter && { user: filter.userFilter }),
+								},
+								include: {
+									user: {
+										include: {
+											person: {
+												include: {
+													students: {
+														where: { isDeleted: false },
+													},
+												},
+											},
+										},
+									},
+								},
+							});
+							break;
+					}
+
+					// Count unique students per program
+					const programStudentSets: Record<string, Set<string>> = {};
+					assessments.forEach((assessment: any) => {
+						const students = assessment.user?.person?.students || [];
+						students.forEach((student: any) => {
+							const program = student.program || "Unknown";
+							if (!programStudentSets[program]) {
+								programStudentSets[program] = new Set();
+							}
+							programStudentSets[program].add(student.id);
+						});
+					});
+
+					return Object.entries(programStudentSets).map(([program, studentSet]) => ({
+						program,
+						[countField]: studentSet.size,
+					}));
+				}
+
+				// Default behavior: fetch all assessment types
+				const [
+					anxietyByProgram,
+					depressionByProgram,
+					stressByProgram,
+					checklistByProgram,
+					suicideByProgram,
+				] = await Promise.all([
+					prisma.anxietyAssessment.findMany({
+						where: {
+							isDeleted: false,
+							...(filter.userFilter && { user: filter.userFilter }),
+						},
+						include: {
+							user: {
+								include: {
+									person: {
+										include: {
+											students: {
+												where: { isDeleted: false },
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+					prisma.depressionAssessment.findMany({
+						where: {
+							isDeleted: false,
+							...(filter.userFilter && { user: filter.userFilter }),
+						},
+						include: {
+							user: {
+								include: {
+									person: {
+										include: {
+											students: {
+												where: { isDeleted: false },
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+					prisma.stressAssessment.findMany({
+						where: {
+							isDeleted: false,
+							...(filter.userFilter && { user: filter.userFilter }),
+						},
+						include: {
+							user: {
+								include: {
+									person: {
+										include: {
+											students: {
+												where: { isDeleted: false },
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+					prisma.personalProblemsChecklist.findMany({
+						where: {
+							isDeleted: false,
+							...(filter.userFilter && { user: filter.userFilter }),
+						},
+						include: {
+							user: {
+								include: {
+									person: {
+										include: {
+											students: {
+												where: { isDeleted: false },
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+					prisma.suicideAssessment.findMany({
+						where: {
+							isDeleted: false,
+							...(filter.userFilter && { user: filter.userFilter }),
+						},
+						include: {
+							user: {
+								include: {
+									person: {
+										include: {
+											students: {
+												where: { isDeleted: false },
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+				]);
+
+				// Create maps to track unique students per program for each assessment type
+				const programMaps: Record<
+					string,
+					{
+						anxiety: Set<string>;
+						depression: Set<string>;
+						stress: Set<string>;
+						checklist: Set<string>;
+						suicide: Set<string>;
+					}
+				> = {};
+
+				// Helper function to add student to program map
+				const addToMap = (
+					assessment: any,
+					assessmentType: "anxiety" | "depression" | "stress" | "checklist" | "suicide",
+				) => {
+					const students = assessment.user?.person?.students || [];
+					students.forEach((student: any) => {
+						const program = student.program || "Unknown";
+						if (!programMaps[program]) {
+							programMaps[program] = {
+								anxiety: new Set(),
+								depression: new Set(),
+								stress: new Set(),
+								checklist: new Set(),
+								suicide: new Set(),
+							};
+						}
+						programMaps[program][assessmentType].add(student.id);
+					});
+				};
+
+				// Process each assessment type
+				anxietyByProgram.forEach((a) => addToMap(a, "anxiety"));
+				depressionByProgram.forEach((d) => addToMap(d, "depression"));
+				stressByProgram.forEach((s) => addToMap(s, "stress"));
+				checklistByProgram.forEach((c) => addToMap(c, "checklist"));
+				suicideByProgram.forEach((s) => addToMap(s, "suicide"));
+
+				// Convert to array format
+				return Object.entries(programMaps).map(([program, sets]) => ({
+					program,
+					anxiety: sets.anxiety.size,
+					depression: sets.depression.size,
+					stress: sets.stress.size,
+					checklist: sets.checklist.size,
+					suicide: sets.suicide.size,
+				}));
 			},
 		},
 		Inventory: {

--- a/prisma/schema/student.prisma
+++ b/prisma/schema/student.prisma
@@ -6,8 +6,9 @@ enum AcademicStatus {
 }
 
 type Notes {
-  title   String?
-  content String?
+  title     String?
+  content   String?
+  createdAt DateTime?
 }
 
 model Student {


### PR DESCRIPTION
This pull request introduces several enhancements and improvements to the metrics dashboard and student note handling. The primary changes include adding support for filtering program distribution by assessment type, improving the validation of note creation dates, and updating the API documentation and Prisma schema accordingly.

**Metrics dashboard improvements:**

* Added a new `assessmentType` query parameter to the metrics dashboard endpoint, allowing the frontend to filter program distribution data by specific assessment types (e.g., anxiety, depression, stress, checklist, suicide, or all). This includes backend logic to fetch and aggregate data accordingly. [[1]](diffhunk://#diff-55d08430a864fda010dbfbaaef6801d3c5e5648e0e3011e1f8ff7f4431f115b6L282-R287) [[2]](diffhunk://#diff-55d08430a864fda010dbfbaaef6801d3c5e5648e0e3011e1f8ff7f4431f115b6L308-R323) [[3]](diffhunk://#diff-55d08430a864fda010dbfbaaef6801d3c5e5648e0e3011e1f8ff7f4431f115b6L413-R416) [[4]](diffhunk://#diff-171cad5346056eab07b1478e3745567ea809564abf103d94494d7bfbf751c757R3130-R3420)
* Updated the OpenAPI documentation and response schema in `metrics.router.ts` to reflect the new query parameters and output structure for the dashboard endpoint. [[1]](diffhunk://#diff-d4e6018b4942a7d53a230148d25e8468da168917ec013c56c209f39fa1e92f9dR220-R233) [[2]](diffhunk://#diff-d4e6018b4942a7d53a230148d25e8468da168917ec013c56c209f39fa1e92f9dL235-R259)
* Added logging to help trace dashboard data fetching and program distribution logic. [[1]](diffhunk://#diff-171cad5346056eab07b1478e3745567ea809564abf103d94494d7bfbf751c757R2815-R2816) [[2]](diffhunk://#diff-171cad5346056eab07b1478e3745567ea809564abf103d94494d7bfbf751c757R3130-R3420)

**Student notes validation:**

* Implemented validation and normalization for the `createdAt` field in student notes to ensure it is a valid date and stored in ISO format. If the date is invalid, the API returns a 400 error. [[1]](diffhunk://#diff-af3f6f1c838aebf8e53f0dcc280879bcfb025427ebdc822cee414cedcad1ac83R304-R318) [[2]](diffhunk://#diff-af3f6f1c838aebf8e53f0dcc280879bcfb025427ebdc822cee414cedcad1ac83R536-R550)
* Updated the Prisma schema to allow an optional `createdAt` field in the `Notes` type.