### PR TITLE
Schema Update

### DIFF
--- a/prisma/schema/consent.prisma
+++ b/prisma/schema/consent.prisma
@@ -30,6 +30,7 @@ enum PhysicalProblem {
 }
 
 enum PhysicalSymptoms {
+  none
   shortness_of_breath
   racing_heart
   headaches
@@ -91,7 +92,7 @@ model Consent {
   financial_status            Financial
   what_brings_you_to_guidance String?
   physical_problem            PhysicalProblem
-  physical_symptoms           PhysicalSymptoms
+  physical_symptoms           PhysicalSymptoms @default(none)
   concerns                    PresentConcerns
   services                    Services?
   isDeleted                   Boolean          @default(false)


### PR DESCRIPTION
This pull request makes a minor update to the `prisma/schema/consent.prisma` schema to improve the handling of physical symptoms in the `Consent` model. The key change is the addition of a `none` value to the `PhysicalSymptoms` enum and setting it as the default for the `physical_symptoms` field.

* Added `none` to the `PhysicalSymptoms` enum to allow representing the absence of physical symptoms.
* Set the default value of the `physical_symptoms` field in the `Consent` model to `none`, ensuring new records have a sensible default.